### PR TITLE
doc: use qwen2.5-coder instead of codellama

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ collama.nvim is a Neovim plugin that leverages Ollama to provide source code com
 
 1. Install the requirements.
 1. Install `collama.nvim` using your preferred package manager.
-1. Run `ollama pull codellama:7b-code`.
-1. Add `require('collama.preset.example').setup({ model = 'codellama:7b-code' })` to your init.lua.
+1. Run `ollama pull qwen2.5-coder:7b`.
+1. Add `require('collama.preset.example').setup({ model = 'qwen2.5-coder:7b' })` to your init.lua.
 1. Add `vim.keymap.set('i', '<M-j>', require('collama.copilot').accept)` to your init.lua.
 1. Open a file in nvim and enter insert mode. Wait for a while.
 1. Press `<M-j>` to accept the suggested code.
@@ -46,7 +46,7 @@ collama.nvim is a Neovim plugin that leverages Ollama to provide source code com
     'yuys13/collama.nvim',
     lazy = false,
     config = function()
-      require('collama.preset.example').setup { model = 'codellama:7b-code' }
+      require('collama.preset.example').setup { model = 'qwen2.5-coder:7b' }
       -- map accept key
       vim.keymap.set('i', '<M-j>', require('collama.copilot').accept)
     end,
@@ -63,7 +63,7 @@ collama.nvim is a Neovim plugin that leverages Ollama to provide source code com
       ---@type CollamaConfig
       local config = {
         base_url = 'http://localhost:11434/api/',
-        model = 'codellama:7b-code',
+        model = 'qwen2.5-coder:7b',
       }
 
       local augroup = vim.api.nvim_create_augroup('my_collama_augroup', { clear = true })
@@ -100,7 +100,7 @@ collama.nvim is a Neovim plugin that leverages Ollama to provide source code com
     'yuys13/collama.nvim',
     lazy = false,
     config = function()
-      require('collama.preset.example').setup { model = 'codellama:7b-code' }
+      require('collama.preset.example').setup { model = 'qwen2.5-coder:7b' }
       -- map accept key
       vim.keymap.set('i', '<M-j>', require('collama.copilot').accept)
 
@@ -118,7 +118,7 @@ collama.nvim is a Neovim plugin that leverages Ollama to provide source code com
     'yuys13/collama.nvim',
     lazy = false,
     config = function()
-      require('collama.preset.example').setup { model = 'codellama:7b-code' }
+      require('collama.preset.example').setup { model = 'qwen2.5-coder:7b' }
       -- map accept key
       vim.keymap.set('i', '<M-j>', require('collama.copilot').accept)
 
@@ -136,7 +136,7 @@ collama.nvim is a Neovim plugin that leverages Ollama to provide source code com
     'yuys13/collama.nvim',
     lazy = false,
     config = function()
-      require('collama.preset.example').setup { model = 'codellama:7b-code' }
+      require('collama.preset.example').setup { model = 'qwen2.5-coder:7b' }
       -- map accept key
       vim.keymap.set('i', '<M-j>', require('collama.copilot').accept)
 


### PR DESCRIPTION
Because `<EOT>` is output when codellama is used with the current ollama.
In ollama5.1, `<EOT>` was not output.
Since qwen2.5-coder has no problem with the current ollama, the model
used in quickstart should be changed.
