### PR TITLE
feat: use OLLAMA_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ collama.nvim is a Neovim plugin that leverages Ollama to provide source code com
     config = function()
       ---@type CollamaConfig
       local config = {
-        base_url = 'http://localhost:11434/api/',
         model = 'qwen2.5-coder:7b',
       }
 

--- a/lua/collama/api.lua
+++ b/lua/collama/api.lua
@@ -71,6 +71,15 @@ function url.join(...)
   return table.concat(temp, '/')
 end
 
+---Get base url
+---@return string
+function M.get_base_url()
+  if vim.env.OLLAMA_HOST then
+    return string.format('http://%s/api/', vim.env.OLLAMA_HOST)
+  end
+  return 'http://127.0.0.1:11434/api/'
+end
+
 ---Request generate API to `url`
 ---@param base_url string
 ---@param body CollamaGenerateRequest

--- a/lua/collama/copilot.lua
+++ b/lua/collama/copilot.lua
@@ -1,5 +1,5 @@
 ---@class CollamaConfig
----@field base_url string
+---@field base_url string?
 ---@field model string
 
 local state = require 'collama.copilot.state'
@@ -69,7 +69,10 @@ function M.request(config)
   state.set_pos()
   local prefix, suffix = get_buffer(state.get_pos())
 
-  local job = require('collama.api').generate(config.base_url, {
+  local api = require 'collama.api'
+  local base_url = config.base_url or api.get_base_url()
+
+  local job = api.generate(base_url, {
     prompt = prefix,
     suffix = suffix,
     model = config.model,

--- a/lua/collama/preset/example.lua
+++ b/lua/collama/preset/example.lua
@@ -1,6 +1,6 @@
 ---@class CollamaExampleSetupConfig
----@field base_url string? default: 'http://localhost:11434/api/'
----@field model string the model name. ex) 'codellama:code'
+---@field base_url string? base_url like `http://localhost:11434/api/`. If nil is specified, fall back to `http://${OLLAMA_HOST}/api/`
+---@field model string the model name. ex) `qwen2.5-coder:7b`
 ---@field debounce_time integer? default: 1000
 
 local M = {}
@@ -10,7 +10,7 @@ local M = {}
 function M.setup(config)
   ---@type CollamaConfig
   local cc = {
-    base_url = config.base_url or 'http://localhost:11434/api/',
+    base_url = config.base_url,
     model = config.model,
   }
   local debounce_time = config.debounce_time or 1000

--- a/test/api_spec.lua
+++ b/test/api_spec.lua
@@ -3,6 +3,28 @@ local stub = require 'luassert.stub'
 local spy = require 'luassert.spy'
 local match = require 'luassert.match'
 
+describe('base_url', function()
+  local backup_ollama_host = vim.env.OLLAMA_HOST
+
+  after_each(function()
+    vim.env.OLLAMA_HOST = backup_ollama_host
+  end)
+
+  it('default', function()
+    vim.env.OLLAMA_HOST = nil
+    local expected = 'http://127.0.0.1:11434/api/'
+    local actual = api.get_base_url()
+    assert.are_equal(expected, actual)
+  end)
+
+  it('OLLAMA_HOST', function()
+    vim.env.OLLAMA_HOST = 'localhost:8080'
+    local expected = 'http://localhost:8080/api/'
+    local actual = api.get_base_url()
+    assert.are_equal(expected, actual)
+  end)
+end)
+
 describe('generate', function()
   it('request with curl', function()
     local mock = stub.new(vim, 'system')

--- a/test/copilot_spec.lua
+++ b/test/copilot_spec.lua
@@ -1,0 +1,92 @@
+local copilot = require 'collama.copilot'
+local stub = require 'luassert.stub'
+local match = require 'luassert.match'
+
+describe('create request', function()
+  local mock
+  local backup_ollama_host = vim.env.OLLAMA_HOST
+
+  before_each(function()
+    mock = stub.new(vim, 'system')
+  end)
+
+  after_each(function()
+    mock:revert()
+    vim.env.OLLAMA_HOST = backup_ollama_host
+  end)
+
+  it('request() default base_url', function()
+    mock = stub.new(vim, 'system')
+    ---@type CollamaConfig
+    local test_config = { model = 'awesome_model' }
+    vim.env.OLLAMA_HOST = nil
+
+    copilot.request(test_config)
+
+    vim.wait(1000, function()
+      local ret, _ = mock:called()
+      return ret
+    end)
+
+    local expected_request_body = { prompt = '', suffix = '', model = 'awesome_model', stream = false }
+
+    assert.spy(mock).called(1)
+    assert.spy(mock).was.called_with({
+      'curl',
+      '-sSL',
+      '--compressed',
+      '-d',
+      vim.json.encode(expected_request_body),
+      'http://127.0.0.1:11434/api/generate',
+    }, { text = true }, match._)
+  end)
+
+  it('request() use OLLAMA_HOST', function()
+    ---@type CollamaConfig
+    local test_config = { model = 'awesome_model' }
+    vim.env.OLLAMA_HOST = 'example.com'
+
+    copilot.request(test_config)
+
+    vim.wait(1000, function()
+      local ret, _ = mock:called()
+      return ret
+    end)
+
+    local expected_request_body = { prompt = '', suffix = '', model = 'awesome_model', stream = false }
+
+    assert.spy(mock).called(1)
+    assert.spy(mock).was.called_with({
+      'curl',
+      '-sSL',
+      '--compressed',
+      '-d',
+      vim.json.encode(expected_request_body),
+      'http://example.com/api/generate',
+    }, { text = true }, match._)
+  end)
+
+  it('request() use base_url', function()
+    ---@type CollamaConfig
+    local test_config = { model = 'awesome_model', base_url = 'http://localhost:11434/api' }
+
+    copilot.request(test_config)
+
+    vim.wait(1000, function()
+      local ret, _ = mock:called()
+      return ret
+    end)
+
+    local expected_request_body = { prompt = '', suffix = '', model = 'awesome_model', stream = false }
+
+    assert.spy(mock).called(1)
+    assert.spy(mock).was.called_with({
+      'curl',
+      '-sSL',
+      '--compressed',
+      '-d',
+      vim.json.encode(expected_request_body),
+      'http://localhost:11434/api/generate',
+    }, { text = true }, match._)
+  end)
+end)


### PR DESCRIPTION
Ollama's CLI reads the connection address from an environment variable called OLLAMA_HOST.
Similarly, collama.nvim can specify the connection address with OLLAMA_HOST.

```bash
$ ollama run --help
Run a model

Usage:
  ollama run MODEL [PROMPT] [flags]

Flags:
      --format string      Response format (e.g. json)
  -h, --help               help for run
      --insecure           Use an insecure registry
      --keepalive string   Duration to keep a model loaded (e.g. 5m)
      --nowordwrap         Don't wrap words to the next line automatically
      --verbose            Show timings for response

Environment Variables:
      OLLAMA_HOST                IP Address for the ollama server (default 127.0.0.1:11434)
      OLLAMA_NOHISTORY           Do not preserve readline history
```

```bash
$ ollama serve --help
Start ollama

Usage:
  ollama serve [flags]

Aliases:
  serve, start

Flags:
  -h, --help   help for serve

Environment Variables:
      OLLAMA_DEBUG               Show additional debug information (e.g. OLLAMA_DEBUG=1)
      OLLAMA_HOST                IP Address for the ollama server (default 127.0.0.1:11434)
      OLLAMA_KEEP_ALIVE          The duration that models stay loaded in memory (default "5m")
      OLLAMA_MAX_LOADED_MODELS   Maximum number of loaded models per GPU
      OLLAMA_MAX_QUEUE           Maximum number of queued requests
      OLLAMA_MODELS              The path to the models directory
      OLLAMA_NUM_PARALLEL        Maximum number of parallel requests
      OLLAMA_NOPRUNE             Do not prune model blobs on startup
      OLLAMA_ORIGINS             A comma separated list of allowed origins
      OLLAMA_SCHED_SPREAD        Always schedule model across all GPUs

      OLLAMA_FLASH_ATTENTION     Enabled flash attention
      OLLAMA_KV_CACHE_TYPE       Quantization type for the K/V cache (default: f16)
      OLLAMA_LLM_LIBRARY         Set LLM library to bypass autodetection
      OLLAMA_GPU_OVERHEAD        Reserve a portion of VRAM per GPU (bytes)
      OLLAMA_LOAD_TIMEOUT        How long to allow model loads to stall before giving up (default "5m")
```