### PR TITLE
refactor: specify `stream = false` in api.generate

### DIFF
--- a/lua/collama/api.lua
+++ b/lua/collama/api.lua
@@ -91,6 +91,7 @@ function M.generate(base_url, body, callback)
   logger.debug('request to ' .. api_url)
   logger.debug('request body = ' .. vim.inspect(body))
 
+  body.stream = false
   local so = vim.system(
     { 'curl', '-sSL', '--compressed', '-d', vim.json.encode(body), api_url },
     { text = true },

--- a/lua/collama/copilot.lua
+++ b/lua/collama/copilot.lua
@@ -76,7 +76,6 @@ function M.request(config)
     prompt = prefix,
     suffix = suffix,
     model = config.model,
-    stream = false,
   }, function(res)
     local response = res.response
     complete_job(response)


### PR DESCRIPTION
Currently, callback in api assumes `stream = false`.
When `stream = true` is needed, I will create a new stream_api.
